### PR TITLE
Updates documentation

### DIFF
--- a/component_config/component_long_description.md
+++ b/component_config/component_long_description.md
@@ -1,4 +1,4 @@
-**⚠ NOTE** This extractor is being decomisioned and replaced by the official [Temelemtry Extractor](https://components.keboola.com/components/keboola.ex-telemetry-data) which provides the same data and is actively maintained.
+**⚠ NOTE** This extractor is being decommissioned and replaced by the official [Telemtry Extractor](https://components.keboola.com/components/keboola.ex-telemetry-data), which provides the same data and is actively maintained.
 
 
 The Keboola metadata extractor downloads information from Keboola's APIs about various objects, users, etc.

--- a/component_config/component_short_description.md
+++ b/component_config/component_short_description.md
@@ -1,1 +1,2 @@
+**⚠ NOTE** This extractor is being decommissioned and replaced by the official [Telemtry Extractor](https://components.keboola.com/components/keboola.ex-telemetry-data).
 Keboola metadata extractor downloads metadata about all objects in your Keboola project.

--- a/component_config/configuration_description.md
+++ b/component_config/configuration_description.md
@@ -1,4 +1,4 @@
-**⚠ NOTE** This extractor is being decomisioned and replaced by the official [Temelemtry Extractor](https://components.keboola.com/components/keboola.ex-telemetry-data) which provides the same data and is actively maintained.
+**⚠ NOTE** This extractor is being decommissioned and replaced by the official [Telemtry Extractor](https://components.keboola.com/components/keboola.ex-telemetry-data), which provides the same data and is actively maintained.
 
 To configure the extractor, either [a management token](https://help.keboola.com/management/account/#tokens) is needed or an [array of storage tokens](https://help.keboola.com/management/project/tokens/) for all projects, for which metadata should be downloaded. Additionally, you'll need to be able to specify the ID of your organization and region, where your projects are located.
 


### PR DESCRIPTION
This pull request updates documentation for the Keboola metadata extractor to correct typos and ensure consistency in the deprecation notice. The most important changes involve fixing spelling errors and aligning the wording of the deprecation message across multiple files.

Documentation updates:

* [`component_config/component_long_description.md`](diffhunk://#diff-4121eca66b6a89b018b9ace827489a0eca12757b1762562cea92b42624e11809L1-R1): Corrected the spelling of "decomisioned" to "decommissioned" and "Temelemtry" to "Telemetry" in the deprecation notice.
* [`component_config/component_short_description.md`](diffhunk://#diff-7ead0ddfffa183f6f921a242af556b6a3ec45cb149ba1164545948ab1a6842deR1): Added a deprecation notice for the extractor, specifying it is being replaced by the official Telemetry Extractor.
* [`component_config/configuration_description.md`](diffhunk://#diff-ea2702ff88f661d64552aa5aaae27f57e0fd55e2f23ae2e28953048bb6f1304aL1-R1): Fixed typos in the deprecation notice, updating "decomisioned" to "decommissioned" and "Temelemtry" to "Telemetry."